### PR TITLE
chore: add apollo 3.5

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -9,6 +9,18 @@
  */
 
 {
+    "initialize-apollo": {
+        "scope": "",
+        "version": "",
+        "mainFile": "index.ts",
+        "rootDir": "api/initialize-apollo",
+        "nextVersion": {
+            "version": "patch",
+            "message": "add apollo 3.5",
+            "username": "dtothefp",
+            "email": "dtothefp@gmail.com"
+        }
+    },
     "verify-soft-tag": {
         "scope": "dtothefp.scripts",
         "version": "0.1.1",

--- a/.bitmap
+++ b/.bitmap
@@ -9,6 +9,18 @@
  */
 
 {
+    "custom-react-env": {
+        "scope": "",
+        "version": "",
+        "mainFile": "index.ts",
+        "rootDir": "envs/custom-react-env",
+        "nextVersion": {
+            "version": "patch",
+            "message": "create custom react env",
+            "username": "dtothefp",
+            "email": "dtothefp@gmail.com"
+        }
+    },
     "initialize-apollo": {
         "scope": "",
         "version": "",

--- a/api/initialize-apollo/index.ts
+++ b/api/initialize-apollo/index.ts
@@ -1,0 +1,1 @@
+export { initializeApollo } from './initialize-apollo';

--- a/api/initialize-apollo/initialize-apollo.composition.tsx
+++ b/api/initialize-apollo/initialize-apollo.composition.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+// import { initializeApollo } from './initialize-apollo';
+
+export function ReturnsCorrectValue() {
+  return <div>TBD</div>;
+}

--- a/api/initialize-apollo/initialize-apollo.docs.mdx
+++ b/api/initialize-apollo/initialize-apollo.docs.mdx
@@ -1,0 +1,10 @@
+---
+labels: ['module']
+description: 'Initializes an Apollo Client'
+---
+
+API:
+
+```ts
+function initializeApollo(): ApolloClient<NormalizedCacheObject>;
+```

--- a/api/initialize-apollo/initialize-apollo.spec.ts
+++ b/api/initialize-apollo/initialize-apollo.spec.ts
@@ -1,0 +1,5 @@
+import { initializeApollo } from './initialize-apollo';
+
+it('should be defined', () => {
+  expect(initializeApollo).toBeDefined();
+});

--- a/api/initialize-apollo/initialize-apollo.ts
+++ b/api/initialize-apollo/initialize-apollo.ts
@@ -1,0 +1,33 @@
+import {
+  from,
+  ApolloClient,
+  HttpLink,
+  InMemoryCache,
+  NormalizedCacheObject,
+} from '@apollo/client';
+
+const uri = process.env.NEXT_PUBLIC_APPSYNC_API_URL || '';
+const apiKey = process.env.NEXT_PUBLIC_APPSYNC_API_KEY || '';
+
+const httpLink = new HttpLink({
+  uri,
+  headers: {
+    'x-api-key': apiKey,
+  },
+});
+
+export function initializeApollo(
+  initialState: null | NormalizedCacheObject = null,
+) {
+  const apolloClient = new ApolloClient({
+    ssrMode: typeof window === 'undefined',
+    link: from([httpLink]),
+    cache: new InMemoryCache(),
+  });
+
+  if (initialState) {
+    apolloClient.cache.restore(initialState);
+  }
+
+  return apolloClient;
+}

--- a/envs/custom-react-env/custom-react-env.aspect.ts
+++ b/envs/custom-react-env/custom-react-env.aspect.ts
@@ -1,0 +1,5 @@
+import { Aspect } from '@teambit/harmony';
+
+export const CustomReactEnvAspect = Aspect.create({
+  id: 'dtothefp.envs/custom-react-env',
+});

--- a/envs/custom-react-env/custom-react-env.docs.mdx
+++ b/envs/custom-react-env/custom-react-env.docs.mdx
@@ -1,0 +1,158 @@
+---
+description: 'A standard React component development environment'
+labels: ['react', 'typescript', 'env', 'extension']
+---
+
+## Overview
+
+A customized version which extends the default React component development environment created by teambit. This environment can be applied to all your components or a set of components under the variants of your `workspace.json` file. That means they will use your custom environment instead of the default environment. Environment components are just like any other Bit components in that they can be exported and then shared and used in various projects which makes it easier to create standards when working with many teams.
+
+### Usage instructions
+
+Under the **variant** section of your `workspace.json` file choose which components you want to have the custom environment set. You can find the id of the extension in the `custom-react-env.aspect.ts` file.
+
+```json
+{
+  "teambit.workspace/variants": {
+    "{ui/**}, {pages/**}": {
+      "dtothefp.envs/custom-react-env": {}
+    }
+  }
+}
+```
+
+## Runtime Configurations
+
+Extend the `main.runtime` file when you want to add custom configurations at runtime.
+
+### Compilation
+
+By default, Component compilation is done with the TypeScript compiler. Target format is `ES2015` which
+supports execution from both NodeJS and browser runtimes for server-side rendering. You can modify the `tsconfig.json` file to add your own compiler options which will then be merged with the default configs set by teambit.
+
+Example:
+
+```json
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "es2015",
+    "moduleResolution": "node",
+    "lib": ["es2017", "dom"],
+    "experimentalDecorators": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "sourceMap": true,
+    "emitDecoratorMetadata": true,
+    "allowJs": true,
+    "baseUrl": ".",
+    "jsx": "react"
+  }
+}
+```
+
+### Testing
+
+Component testing is done through [Jest](https://jestjs.io/) with the default `teambit.react/react` environment. You can modify the `jestconfig.js` file to add your own configurations which will then be merged with the default configs set by teambit.
+
+Example:
+
+To Override the Jest config to ignore transpiling from specific folders add this to the `jestconfig.js` file:
+
+```js
+const reactJestConfig = require('@teambit/react/jest/jest.config');
+module.exports = {
+  ...reactJestConfig,
+  transformIgnorePatterns: ['/node_modules/(?!(prop-types|@teambit))']
+};
+```
+
+### Webpack
+
+Bit uses webpack 5 to bundle components. You can modify the `webpack.config.js` file to add your own configurations which will then be merged with the default configs set by teambit.
+
+Example:
+
+```ts
+module.exports = {
+  module: {
+    // add your custom rules here
+    rules: []
+  }
+};
+```
+
+### ESLint
+
+Bit uses ESLint to lint your components. You can add your own rules in the `custom-react-env.main.runtime` file.
+
+Example:
+
+```ts
+react.useEslint({
+  transformers: [
+    (config) => {
+      config.setRule('no-console', ['error']);
+      // add more rules here
+      return config;
+    }
+  ]
+}),
+```
+
+To use ESLint:
+
+```bash
+bit lint
+bit lint --fix
+```
+
+### Formatting
+
+Bit uses Prettier to format your components. You can add your own rules in the `custom-react-env.main.runtime` file.
+
+Example:
+
+```ts
+react.usePrettier({
+  transformers: [
+    (config) => {
+      config.setKey('tabWidth', 2);
+      // add more rules here
+      return config;
+    }
+  ]
+}),
+```
+
+To use Prettier:
+
+```bash
+bit format --check
+bit format
+```
+
+### Dependencies
+
+Override the default dependencies in the `custom-react-env.main.runtime` file to include react types of a different version for example.
+
+```ts
+react.overrideDependencies({
+  devDependencies: {
+    '@types/react': '17.0.3'
+  }
+});
+```
+
+## Preview Configurations
+
+Extend the `custom-react-env.preview.runtime` file when you want to add your own customizations only for previewing in the Bit UI.
+
+### Adding a Theme
+
+A custom theme has been added to the env which wraps all the composition files with the required theme so they can be developed with the correct themeing rather than the browsers default. This is added only in the preview runtime and not in the main runtime meaning it is only applied to compositions and not when consuming components. Adding a theme when consuming should be done at App level as you component may be consumed in various apps and have different themes applied depending on where it is consumed.
+
+Example:
+
+```ts
+react.registerProvider([ThemeCompositions]);

--- a/envs/custom-react-env/custom-react-env.main.runtime.ts
+++ b/envs/custom-react-env/custom-react-env.main.runtime.ts
@@ -1,0 +1,80 @@
+/* eslint max-len:0 */
+import { MainRuntime } from '@teambit/cli';
+import { ReactAspect, ReactMain } from '@teambit/react';
+import { EnvsAspect, EnvsMain } from '@teambit/envs';
+import { CustomReactEnvAspect } from './custom-react-env.aspect';
+// import { previewConfigTransformer, devServerConfigTransformer } from './webpack/webpack-transformers';
+
+/**
+ * Uncomment to include config files for overrides of Typescript or Webpack
+ */
+// const tsconfig = require('./typescript/tsconfig');
+
+export class CustomReactEnvMain {
+  static slots = [];
+
+  static dependencies = [ReactAspect, EnvsAspect];
+
+  static runtime = MainRuntime;
+
+  static async provider([react, envs]: [ReactMain, EnvsMain]) {
+    const templatesReactEnv = envs.compose(react.reactEnv, [
+      /**
+       * Uncomment to override the config files for TypeScript, Webpack or Jest
+       * Your config gets merged with the defaults
+       */
+
+      // react.overrideTsConfig(tsconfig),
+      // react.useWebpack({
+      //   previewConfig: [previewConfigTransformer],
+      //   devServerConfig: [devServerConfigTransformer],
+      // }),
+      react.overrideJestConfig(require.resolve('./jest/jest.config')),
+
+      /**
+       * override the ESLint default config here then check your files for lint errors
+       * @example
+       * bit lint
+       * bit lint --fix
+       */
+      react.useEslint({
+        transformers: [
+          (config) => {
+            config.setRule('no-console', ['error']);
+            return config;
+          },
+        ],
+      }),
+
+      /**
+       * override the Prettier default config here the check your formatting
+       * @example
+       * bit format --check
+       * bit format
+       */
+      react.usePrettier({
+        transformers: [
+          (config) => {
+            config.setKey('tabWidth', 2);
+            return config;
+          },
+        ],
+      }),
+
+      /**
+       * override dependencies here
+       * @example
+       * Uncomment types to include version 17.0.3 of the types package
+       */
+      react.overrideDependencies({
+        devDependencies: {
+          // '@types/react': '17.0.3'
+        },
+      }),
+    ]);
+    envs.registerEnv(templatesReactEnv);
+    return new CustomReactEnvMain();
+  }
+}
+
+CustomReactEnvAspect.addRuntime(CustomReactEnvMain);

--- a/envs/custom-react-env/custom-react-env.preview.runtime.ts
+++ b/envs/custom-react-env/custom-react-env.preview.runtime.ts
@@ -1,0 +1,23 @@
+/* eslint max-len:0,@typescript-eslint/no-unused-vars:0 */
+import { PreviewRuntime } from '@teambit/preview';
+import { ReactAspect, ReactPreview } from '@teambit/react';
+// uncomment the line below and install the theme if you want to use our theme or create your own and import it here
+// import { ThemeCompositions } from '@teambit/documenter.theme.theme-compositions';
+
+import { CustomReactEnvAspect } from './custom-react-env.aspect';
+
+export class CustomReactEnvPreviewMain {
+  static runtime = PreviewRuntime;
+
+  static dependencies = [ReactAspect];
+
+  static async provider([react]: [ReactPreview]) {
+    const customReactEnvPreviewMain = new CustomReactEnvPreviewMain();
+    // uncomment the line below to register a new provider to wrap all compositions using this environment with a custom theme.
+    // react.registerProvider([ThemeCompositions]);
+
+    return customReactEnvPreviewMain;
+  }
+}
+
+CustomReactEnvAspect.addRuntime(CustomReactEnvPreviewMain);

--- a/envs/custom-react-env/index.ts
+++ b/envs/custom-react-env/index.ts
@@ -1,0 +1,5 @@
+import { CustomReactEnvAspect } from './custom-react-env.aspect';
+
+export type { CustomReactEnvMain } from './custom-react-env.main.runtime';
+export default CustomReactEnvAspect;
+export { CustomReactEnvAspect };

--- a/envs/custom-react-env/jest/jest.config.js
+++ b/envs/custom-react-env/jest/jest.config.js
@@ -1,0 +1,19 @@
+// Override the Jest config to ignore transpiling from specific folders
+// See the base Jest config: https://bit.dev/teambit/react/react/~code/jest/jest.config.js
+
+const reactJestConfig = require('@teambit/react/jest/jest.config');
+
+// uncomment the line below and install the package if you want to use this function
+const {
+  generateNodeModulesPattern,
+} = require('@teambit/dependencies.modules.packages-excluder');
+
+const packagesToExclude = ['prop-types', '@teambit'];
+
+module.exports = {
+  ...reactJestConfig,
+  transformIgnorePatterns: [
+    ...reactJestConfig.transformIgnorePatterns,
+    `/${generateNodeModulesPattern({ packages: packagesToExclude })}`,
+  ],
+};

--- a/envs/custom-react-env/typescript/tsconfig.json
+++ b/envs/custom-react-env/typescript/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  // add your compiler options here
+
+  "compilerOptions": {
+    // "target": "es2017",
+    // "module": "es2015",
+    // "moduleResolution": "node",
+    // "lib": ["es2017", "dom"],
+    // "experimentalDecorators": true,
+    // "esModuleInterop": true,
+    // "outDir": "dist",
+    // "sourceMap": true,
+    // "emitDecoratorMetadata": true,
+    // "allowJs": true,
+    // "baseUrl": ".",
+    // "jsx": "react"
+  }
+}

--- a/envs/custom-react-env/webpack/webpack-transformers.ts
+++ b/envs/custom-react-env/webpack/webpack-transformers.ts
@@ -1,0 +1,44 @@
+/* eslint max-len:0 */
+import { WebpackConfigTransformer, WebpackConfigMutator, WebpackConfigTransformContext } from '@teambit/webpack';
+
+/**
+   * Transformation to apply for both preview and dev server
+   * @param config
+   * @param _context
+   */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function commonTransformation(config: WebpackConfigMutator, _context: WebpackConfigTransformContext) {
+  // Merge config with the webpack.config.js file if you choose to import a module export format config.
+  // config.merge([webpackConfig]);
+  // config.addAliases({});
+  // config.addModuleRule(youRuleHere);
+  return config;
+}
+
+/**
+   * Transformation for the preview only
+   * @param config
+   * @param context
+   * @returns
+   */
+export const previewConfigTransformer: WebpackConfigTransformer = (
+  config: WebpackConfigMutator,
+  context: WebpackConfigTransformContext,
+) => {
+  const newConfig = commonTransformation(config, context);
+  return newConfig;
+};
+
+/**
+   * Transformation for the dev server only
+   * @param config
+   * @param context
+   * @returns
+   */
+export const devServerConfigTransformer: WebpackConfigTransformer = (
+  config: WebpackConfigMutator,
+  context: WebpackConfigTransformContext,
+) => {
+  const newConfig = commonTransformation(config, context);
+  return newConfig;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,8 @@ importers:
       '@babel/runtime': 7.12.18
       '@commitlint/cli': 15.0.0
       '@commitlint/config-conventional': 15.0.0
+      '@teambit/dependencies.modules.packages-excluder': 0.0.49
+      '@teambit/harmony': 0.2.11
       '@testing-library/react': 12.1.2
       '@types/jest': 26.0.20
       '@types/node': 12.20.4
@@ -25,6 +27,8 @@ importers:
       '@apollo/client': registry.npmjs.org/@apollo/client/3.5.6_graphql@16.0.1+react@17.0.2
       '@commitlint/cli': registry.npmjs.org/@commitlint/cli/15.0.0
       '@commitlint/config-conventional': registry.npmjs.org/@commitlint/config-conventional/15.0.0
+      '@teambit/dependencies.modules.packages-excluder': registry.npmjs.org/@teambit/dependencies.modules.packages-excluder/0.0.49_react@17.0.2
+      '@teambit/harmony': registry.npmjs.org/@teambit/harmony/0.2.11
       '@testing-library/react': registry.npmjs.org/@testing-library/react/12.1.2_react-dom@17.0.2+react@17.0.2
       chalk: registry.npmjs.org/chalk/4.1.2
       core-js: registry.npmjs.org/core-js/3.20.0
@@ -45,6 +49,9 @@ importers:
     specifiers: {}
 
   base-level/atom/component:
+    specifiers: {}
+
+  envs/custom-react-env:
     specifiers: {}
 
   high-level/organism/component:
@@ -354,6 +361,33 @@ packages:
       chalk: registry.npmjs.org/chalk/4.1.2
     dev: false
 
+  registry.npmjs.org/@teambit/dependencies.modules.packages-excluder/0.0.49_react@17.0.2:
+    resolution: {integrity: sha512-5tRnzisN18Wtwr0+kgN+XC9Q25UbVlatmqDsY+S0Fd33CcmYTcZnYzG84vkGGb6H+Ly/6dGqdx0+WnRnZgW9Jw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/dependencies.modules.packages-excluder/-/dependencies.modules.packages-excluder-0.0.49.tgz}
+    id: registry.npmjs.org/@teambit/dependencies.modules.packages-excluder/0.0.49
+    name: '@teambit/dependencies.modules.packages-excluder'
+    version: 0.0.49
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      '@teambit/legacy': 1.0.190
+      react: 17.0.2
+    dependencies:
+      react: registry.npmjs.org/react/17.0.2
+    dev: false
+
+  registry.npmjs.org/@teambit/harmony/0.2.11:
+    resolution: {integrity: sha512-yw24BeFdXteV/cNBh+Bx7uG1wyW3DQSwuYtqkGa+9JavL/C5HxqdyqXI4AVkgjzu2ghxlojTh74m27MkIcgSeQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/harmony/-/harmony-0.2.11.tgz}
+    name: '@teambit/harmony'
+    version: 0.2.11
+    dependencies:
+      cleargraph: registry.npmjs.org/cleargraph/5.8.0
+      comment-json: registry.npmjs.org/comment-json/3.0.3
+      fs-extra: registry.npmjs.org/fs-extra/8.1.0
+      lodash: registry.npmjs.org/lodash/4.17.21
+      loud-rejection: registry.npmjs.org/loud-rejection/1.6.0
+      reflect-metadata: registry.npmjs.org/reflect-metadata/0.1.13
+      user-home: registry.npmjs.org/user-home/2.0.0
+    dev: false
+
   registry.npmjs.org/@testing-library/dom/8.11.1:
     resolution: {integrity: sha512-3KQDyx9r0RKYailW2MiYrSSKEfH0GTkI51UGEvJenvcoDoeRYs0PZpi2SXqtnMClQvCqdtTTpOfFETDTVADpAg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.1.tgz}
     name: '@testing-library/dom'
@@ -582,6 +616,13 @@ packages:
     engines: {node: '>=6.0'}
     dev: false
 
+  registry.npmjs.org/array-find-index/1.0.2:
+    resolution: {integrity: sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz}
+    name: array-find-index
+    version: 1.0.2
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   registry.npmjs.org/array-ify/1.0.0:
     resolution: {integrity: sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz}
     name: array-ify
@@ -646,6 +687,15 @@ packages:
       ansi-styles: registry.npmjs.org/ansi-styles/4.3.0
       supports-color: registry.npmjs.org/supports-color/7.2.0
 
+  registry.npmjs.org/cleargraph/5.8.0:
+    resolution: {integrity: sha512-72ZcdfWOwa1w3IfvKQFBp9lbgeZVlx9VFzUEKuGebaWprKIRs+kLIz48cNPAE8A6ZhuIbDsdFbYPQBH85+viRw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/cleargraph/-/cleargraph-5.8.0.tgz}
+    name: cleargraph
+    version: 5.8.0
+    dependencies:
+      graphlib: registry.npmjs.org/graphlib/2.1.8
+      lodash: registry.npmjs.org/lodash/4.17.21
+    dev: false
+
   registry.npmjs.org/cliui/7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz}
     name: cliui
@@ -682,6 +732,18 @@ packages:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz}
     name: color-name
     version: 1.1.4
+
+  registry.npmjs.org/comment-json/3.0.3:
+    resolution: {integrity: sha512-P7XwYkC3qjIK45EAa9c5Y3lR7SMXhJqwFdWg3niAIAcbk3zlpKDdajV8Hyz/Y3sGNn3l+YNMl8A2N/OubSArHg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/comment-json/-/comment-json-3.0.3.tgz}
+    name: comment-json
+    version: 3.0.3
+    engines: {node: '>= 6'}
+    dependencies:
+      core-util-is: registry.npmjs.org/core-util-is/1.0.3
+      esprima: registry.npmjs.org/esprima/4.0.1
+      has-own-prop: registry.npmjs.org/has-own-prop/2.0.0
+      repeat-string: registry.npmjs.org/repeat-string/1.6.1
+    dev: false
 
   registry.npmjs.org/compare-func/2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz}
@@ -735,6 +797,12 @@ packages:
     requiresBuild: true
     dev: false
 
+  registry.npmjs.org/core-util-is/1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz}
+    name: core-util-is
+    version: 1.0.3
+    dev: false
+
   registry.npmjs.org/cosmiconfig/7.0.1:
     resolution: {integrity: sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz}
     name: cosmiconfig
@@ -770,6 +838,15 @@ packages:
     name: csstype
     version: 3.0.10
     dev: true
+
+  registry.npmjs.org/currently-unhandled/0.4.1:
+    resolution: {integrity: sha1-mI3zP+qxke95mmE2nddsF635V+o=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz}
+    name: currently-unhandled
+    version: 0.4.1
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      array-find-index: registry.npmjs.org/array-find-index/1.0.2
+    dev: false
 
   registry.npmjs.org/dargs/7.0.0:
     resolution: {integrity: sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz}
@@ -852,6 +929,14 @@ packages:
     engines: {node: '>=0.8.0'}
     dev: false
 
+  registry.npmjs.org/esprima/4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz}
+    name: esprima
+    version: 4.0.1
+    engines: {node: '>=4'}
+    hasBin: true
+    dev: false
+
   registry.npmjs.org/execa/5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/execa/-/execa-5.1.1.tgz}
     name: execa
@@ -898,6 +983,17 @@ packages:
       graceful-fs: registry.npmjs.org/graceful-fs/4.2.8
       jsonfile: registry.npmjs.org/jsonfile/6.1.0
       universalify: registry.npmjs.org/universalify/2.0.0
+    dev: false
+
+  registry.npmjs.org/fs-extra/8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz}
+    name: fs-extra
+    version: 8.1.0
+    engines: {node: '>=6 <7 || >=8'}
+    dependencies:
+      graceful-fs: registry.npmjs.org/graceful-fs/4.2.8
+      jsonfile: registry.npmjs.org/jsonfile/4.0.0
+      universalify: registry.npmjs.org/universalify/0.1.2
     dev: false
 
   registry.npmjs.org/function-bind/1.1.1:
@@ -949,6 +1045,14 @@ packages:
     version: 4.2.8
     dev: false
 
+  registry.npmjs.org/graphlib/2.1.8:
+    resolution: {integrity: sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz}
+    name: graphlib
+    version: 2.1.8
+    dependencies:
+      lodash: registry.npmjs.org/lodash/4.17.21
+    dev: false
+
   registry.npmjs.org/graphql-tag/2.12.6_graphql@16.0.1:
     resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz}
     id: registry.npmjs.org/graphql-tag/2.12.6
@@ -988,6 +1092,13 @@ packages:
     name: has-flag
     version: 4.0.0
     engines: {node: '>=8'}
+
+  registry.npmjs.org/has-own-prop/2.0.0:
+    resolution: {integrity: sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz}
+    name: has-own-prop
+    version: 2.0.0
+    engines: {node: '>=8'}
+    dev: false
 
   registry.npmjs.org/has/1.0.3:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/has/-/has-1.0.3.tgz}
@@ -1159,6 +1270,14 @@ packages:
     version: 3.0.0
     dev: false
 
+  registry.npmjs.org/jsonfile/4.0.0:
+    resolution: {integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz}
+    name: jsonfile
+    version: 4.0.0
+    optionalDependencies:
+      graceful-fs: registry.npmjs.org/graceful-fs/4.2.8
+    dev: false
+
   registry.npmjs.org/jsonfile/6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz}
     name: jsonfile
@@ -1226,6 +1345,16 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: registry.npmjs.org/js-tokens/4.0.0
+    dev: false
+
+  registry.npmjs.org/loud-rejection/1.6.0:
+    resolution: {integrity: sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz}
+    name: loud-rejection
+    version: 1.6.0
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      currently-unhandled: registry.npmjs.org/currently-unhandled/0.4.1
+      signal-exit: registry.npmjs.org/signal-exit/3.0.6
     dev: false
 
   registry.npmjs.org/lru-cache/6.0.0:
@@ -1369,6 +1498,13 @@ packages:
     dependencies:
       '@wry/context': registry.npmjs.org/@wry/context/0.6.1
       '@wry/trie': registry.npmjs.org/@wry/trie/0.3.1
+    dev: false
+
+  registry.npmjs.org/os-homedir/1.0.2:
+    resolution: {integrity: sha1-/7xJiDNuDoM94MFox+8VISGqf7M=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz}
+    name: os-homedir
+    version: 1.0.2
+    engines: {node: '>=0.10.0'}
     dev: false
 
   registry.npmjs.org/p-limit/2.3.0:
@@ -1589,10 +1725,23 @@ packages:
       strip-indent: registry.npmjs.org/strip-indent/3.0.0
     dev: false
 
+  registry.npmjs.org/reflect-metadata/0.1.13:
+    resolution: {integrity: sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz}
+    name: reflect-metadata
+    version: 0.1.13
+    dev: false
+
   registry.npmjs.org/regenerator-runtime/0.13.9:
     resolution: {integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz}
     name: regenerator-runtime
     version: 0.13.9
+
+  registry.npmjs.org/repeat-string/1.6.1:
+    resolution: {integrity: sha1-jcrkcOHIirwtYA//Sndihtp15jc=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz}
+    name: repeat-string
+    version: 1.6.1
+    engines: {node: '>=0.10'}
+    dev: false
 
   registry.npmjs.org/require-directory/2.1.1:
     resolution: {integrity: sha1-jGStX9MNqxyXbiNE/+f3kqam30I=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz}
@@ -1900,11 +2049,27 @@ packages:
     hasBin: true
     dev: false
 
+  registry.npmjs.org/universalify/0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz}
+    name: universalify
+    version: 0.1.2
+    engines: {node: '>= 4.0.0'}
+    dev: false
+
   registry.npmjs.org/universalify/2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz}
     name: universalify
     version: 2.0.0
     engines: {node: '>= 10.0.0'}
+    dev: false
+
+  registry.npmjs.org/user-home/2.0.0:
+    resolution: {integrity: sha1-nHC/2Babwdy/SGBODwS4tJzenp8=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz}
+    name: user-home
+    version: 2.0.0
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      os-homedir: registry.npmjs.org/os-homedir/1.0.2
     dev: false
 
   registry.npmjs.org/util-deprecate/1.0.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,30 +4,49 @@ importers:
 
   .:
     specifiers:
+      '@apollo/client': ^3.5.5
       '@babel/runtime': 7.12.18
       '@commitlint/cli': 15.0.0
       '@commitlint/config-conventional': 15.0.0
       '@testing-library/react': 12.1.2
       '@types/jest': 26.0.20
       '@types/node': 12.20.4
+      '@types/react': ^17.0.8
+      '@types/react-dom': ^17.0.5
+      '@types/testing-library__jest-dom': 5.9.5
       chalk: 4.1.2
+      core-js: ^3.0.0
+      graphql: 16.0.1
       husky: 7.0.4
+      js-cookie: 3.0.1
       jsonc-parser: 3.0.0
+      lodash: 4.17.21
       react: 17.0.2
-      react-dom: 17.0.2
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
+      '@apollo/client': registry.npmjs.org/@apollo/client/3.5.6_graphql@16.0.1+react@17.0.2
       '@commitlint/cli': registry.npmjs.org/@commitlint/cli/15.0.0
       '@commitlint/config-conventional': registry.npmjs.org/@commitlint/config-conventional/15.0.0
       '@testing-library/react': registry.npmjs.org/@testing-library/react/12.1.2_react-dom@17.0.2+react@17.0.2
       chalk: registry.npmjs.org/chalk/4.1.2
+      core-js: registry.npmjs.org/core-js/3.20.0
+      graphql: registry.npmjs.org/graphql/16.0.1
       husky: registry.npmjs.org/husky/7.0.4
+      js-cookie: registry.npmjs.org/js-cookie/3.0.1
       jsonc-parser: registry.npmjs.org/jsonc-parser/3.0.0
+      lodash: registry.npmjs.org/lodash/4.17.21
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     devDependencies:
       '@babel/runtime': registry.npmjs.org/@babel/runtime/7.12.18
       '@types/jest': registry.npmjs.org/@types/jest/26.0.20
       '@types/node': registry.npmjs.org/@types/node/12.20.4
+      '@types/react': registry.npmjs.org/@types/react/17.0.37
+      '@types/react-dom': registry.npmjs.org/@types/react-dom/17.0.11
+      '@types/testing-library__jest-dom': registry.npmjs.org/@types/testing-library__jest-dom/5.9.5
+
+  api/initialize-apollo:
+    specifiers: {}
 
   base-level/atom/component:
     specifiers: {}
@@ -45,6 +64,37 @@ importers:
     specifiers: {}
 
 packages:
+
+  registry.npmjs.org/@apollo/client/3.5.6_graphql@16.0.1+react@17.0.2:
+    resolution: {integrity: sha512-XHoouuEJ4L37mtfftcHHO1caCRrKKAofAwqRoq28UQIPMJk+e7n3X9OtRRNXKk/9tmhNkwelSary+EilfPwI7A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@apollo/client/-/client-3.5.6.tgz}
+    id: registry.npmjs.org/@apollo/client/3.5.6
+    name: '@apollo/client'
+    version: 3.5.6
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      react: ^16.8.0 || ^17.0.0
+      subscriptions-transport-ws: ^0.9.0 || ^0.11.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      subscriptions-transport-ws:
+        optional: true
+    dependencies:
+      '@graphql-typed-document-node/core': registry.npmjs.org/@graphql-typed-document-node/core/3.1.1_graphql@16.0.1
+      '@wry/context': registry.npmjs.org/@wry/context/0.6.1
+      '@wry/equality': registry.npmjs.org/@wry/equality/0.5.2
+      '@wry/trie': registry.npmjs.org/@wry/trie/0.3.1
+      graphql: registry.npmjs.org/graphql/16.0.1
+      graphql-tag: registry.npmjs.org/graphql-tag/2.12.6_graphql@16.0.1
+      hoist-non-react-statics: registry.npmjs.org/hoist-non-react-statics/3.3.2
+      optimism: registry.npmjs.org/optimism/0.16.1
+      prop-types: registry.npmjs.org/prop-types/15.7.2
+      react: registry.npmjs.org/react/17.0.2
+      symbol-observable: registry.npmjs.org/symbol-observable/4.0.0
+      ts-invariant: registry.npmjs.org/ts-invariant/0.9.4
+      tslib: registry.npmjs.org/tslib/2.3.1
+      zen-observable-ts: registry.npmjs.org/zen-observable-ts/1.2.3
+    dev: false
 
   registry.npmjs.org/@babel/code-frame/7.16.0:
     resolution: {integrity: sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz}
@@ -271,6 +321,17 @@ packages:
       - typescript
     dev: false
 
+  registry.npmjs.org/@graphql-typed-document-node/core/3.1.1_graphql@16.0.1:
+    resolution: {integrity: sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz}
+    id: registry.npmjs.org/@graphql-typed-document-node/core/3.1.1
+    name: '@graphql-typed-document-node/core'
+    version: 3.1.1
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      graphql: registry.npmjs.org/graphql/16.0.1
+    dev: false
+
   registry.npmjs.org/@jest/types/26.6.2:
     resolution: {integrity: sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz}
     name: '@jest/types'
@@ -386,6 +447,44 @@ packages:
     version: 4.0.0
     dev: false
 
+  registry.npmjs.org/@types/prop-types/15.7.4:
+    resolution: {integrity: sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz}
+    name: '@types/prop-types'
+    version: 15.7.4
+    dev: true
+
+  registry.npmjs.org/@types/react-dom/17.0.11:
+    resolution: {integrity: sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz}
+    name: '@types/react-dom'
+    version: 17.0.11
+    dependencies:
+      '@types/react': registry.npmjs.org/@types/react/17.0.37
+    dev: true
+
+  registry.npmjs.org/@types/react/17.0.37:
+    resolution: {integrity: sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/react/-/react-17.0.37.tgz}
+    name: '@types/react'
+    version: 17.0.37
+    dependencies:
+      '@types/prop-types': registry.npmjs.org/@types/prop-types/15.7.4
+      '@types/scheduler': registry.npmjs.org/@types/scheduler/0.16.2
+      csstype: registry.npmjs.org/csstype/3.0.10
+    dev: true
+
+  registry.npmjs.org/@types/scheduler/0.16.2:
+    resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz}
+    name: '@types/scheduler'
+    version: 0.16.2
+    dev: true
+
+  registry.npmjs.org/@types/testing-library__jest-dom/5.9.5:
+    resolution: {integrity: sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz}
+    name: '@types/testing-library__jest-dom'
+    version: 5.9.5
+    dependencies:
+      '@types/jest': registry.npmjs.org/@types/jest/26.0.20
+    dev: true
+
   registry.npmjs.org/@types/yargs-parser/20.2.1:
     resolution: {integrity: sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz}
     name: '@types/yargs-parser'
@@ -405,6 +504,33 @@ packages:
     version: 16.0.4
     dependencies:
       '@types/yargs-parser': registry.npmjs.org/@types/yargs-parser/20.2.1
+    dev: false
+
+  registry.npmjs.org/@wry/context/0.6.1:
+    resolution: {integrity: sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz}
+    name: '@wry/context'
+    version: 0.6.1
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: registry.npmjs.org/tslib/2.3.1
+    dev: false
+
+  registry.npmjs.org/@wry/equality/0.5.2:
+    resolution: {integrity: sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@wry/equality/-/equality-0.5.2.tgz}
+    name: '@wry/equality'
+    version: 0.5.2
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: registry.npmjs.org/tslib/2.3.1
+    dev: false
+
+  registry.npmjs.org/@wry/trie/0.3.1:
+    resolution: {integrity: sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@wry/trie/-/trie-0.3.1.tgz}
+    name: '@wry/trie'
+    version: 0.3.1
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: registry.npmjs.org/tslib/2.3.1
     dev: false
 
   registry.npmjs.org/JSONStream/1.3.5:
@@ -606,6 +732,13 @@ packages:
       through2: registry.npmjs.org/through2/4.0.2
     dev: false
 
+  registry.npmjs.org/core-js/3.20.0:
+    resolution: {integrity: sha512-KjbKU7UEfg4YPpskMtMXPhUKn7m/1OdTHTVjy09ScR2LVaoUXe8Jh0UdvN2EKUR6iKTJph52SJP95mAB0MnVLQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/core-js/-/core-js-3.20.0.tgz}
+    name: core-js
+    version: 3.20.0
+    requiresBuild: true
+    dev: false
+
   registry.npmjs.org/cosmiconfig/7.0.1:
     resolution: {integrity: sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz}
     name: cosmiconfig
@@ -635,6 +768,12 @@ packages:
       shebang-command: registry.npmjs.org/shebang-command/2.0.0
       which: registry.npmjs.org/which/2.0.2
     dev: false
+
+  registry.npmjs.org/csstype/3.0.10:
+    resolution: {integrity: sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz}
+    name: csstype
+    version: 3.0.10
+    dev: true
 
   registry.npmjs.org/dargs/7.0.0:
     resolution: {integrity: sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz}
@@ -814,6 +953,26 @@ packages:
     version: 4.2.8
     dev: false
 
+  registry.npmjs.org/graphql-tag/2.12.6_graphql@16.0.1:
+    resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz}
+    id: registry.npmjs.org/graphql-tag/2.12.6
+    name: graphql-tag
+    version: 2.12.6
+    engines: {node: '>=10'}
+    peerDependencies:
+      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      graphql: registry.npmjs.org/graphql/16.0.1
+      tslib: registry.npmjs.org/tslib/2.3.1
+    dev: false
+
+  registry.npmjs.org/graphql/16.0.1:
+    resolution: {integrity: sha512-oPvCuu6dlLdiz8gZupJ47o1clgb72r1u8NDBcQYjcV6G/iEdmE11B1bBlkhXRvV0LisP/SXRFP7tT6AgaTjpzg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/graphql/-/graphql-16.0.1.tgz}
+    name: graphql
+    version: 16.0.1
+    engines: {node: ^12.22.0 || ^14.16.0 || >=16.0.0}
+    dev: false
+
   registry.npmjs.org/hard-rejection/2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz}
     name: hard-rejection
@@ -841,6 +1000,14 @@ packages:
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: registry.npmjs.org/function-bind/1.1.1
+    dev: false
+
+  registry.npmjs.org/hoist-non-react-statics/3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz}
+    name: hoist-non-react-statics
+    version: 3.3.2
+    dependencies:
+      react-is: registry.npmjs.org/react-is/16.13.1
     dev: false
 
   registry.npmjs.org/hosted-git-info/2.8.9:
@@ -977,6 +1144,13 @@ packages:
     version: 26.3.0
     engines: {node: '>= 10.14.2'}
     dev: true
+
+  registry.npmjs.org/js-cookie/3.0.1:
+    resolution: {integrity: sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz}
+    name: js-cookie
+    version: 3.0.1
+    engines: {node: '>=12'}
+    dev: false
 
   registry.npmjs.org/js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz}
@@ -1199,6 +1373,15 @@ packages:
       mimic-fn: registry.npmjs.org/mimic-fn/2.1.0
     dev: false
 
+  registry.npmjs.org/optimism/0.16.1:
+    resolution: {integrity: sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz}
+    name: optimism
+    version: 0.16.1
+    dependencies:
+      '@wry/context': registry.npmjs.org/@wry/context/0.6.1
+      '@wry/trie': registry.npmjs.org/@wry/trie/0.3.1
+    dev: false
+
   registry.npmjs.org/p-limit/2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz}
     name: p-limit
@@ -1314,6 +1497,16 @@ packages:
       react-is: registry.npmjs.org/react-is/17.0.2
     dev: false
 
+  registry.npmjs.org/prop-types/15.7.2:
+    resolution: {integrity: sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz}
+    name: prop-types
+    version: 15.7.2
+    dependencies:
+      loose-envify: registry.npmjs.org/loose-envify/1.4.0
+      object-assign: registry.npmjs.org/object-assign/4.1.1
+      react-is: registry.npmjs.org/react-is/16.13.1
+    dev: false
+
   registry.npmjs.org/q/1.5.1:
     resolution: {integrity: sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/q/-/q-1.5.1.tgz}
     name: q
@@ -1340,6 +1533,12 @@ packages:
       object-assign: registry.npmjs.org/object-assign/4.1.1
       react: registry.npmjs.org/react/17.0.2
       scheduler: registry.npmjs.org/scheduler/0.20.2
+    dev: false
+
+  registry.npmjs.org/react-is/16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz}
+    name: react-is
+    version: 16.13.1
     dev: false
 
   registry.npmjs.org/react-is/17.0.2:
@@ -1614,6 +1813,13 @@ packages:
     dependencies:
       has-flag: registry.npmjs.org/has-flag/4.0.0
 
+  registry.npmjs.org/symbol-observable/4.0.0:
+    resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz}
+    name: symbol-observable
+    version: 4.0.0
+    engines: {node: '>=0.10'}
+    dev: false
+
   registry.npmjs.org/text-extensions/1.9.0:
     resolution: {integrity: sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz}
     name: text-extensions
@@ -1640,6 +1846,15 @@ packages:
     name: trim-newlines
     version: 3.0.1
     engines: {node: '>=8'}
+    dev: false
+
+  registry.npmjs.org/ts-invariant/0.9.4:
+    resolution: {integrity: sha512-63jtX/ZSwnUNi/WhXjnK8kz4cHHpYS60AnmA6ixz17l7E12a5puCWFlNpkne5Rl0J8TBPVHpGjsj4fxs8ObVLQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.4.tgz}
+    name: ts-invariant
+    version: 0.9.4
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: registry.npmjs.org/tslib/2.3.1
     dev: false
 
   registry.npmjs.org/ts-node/9.1.1_typescript@4.5.2:
@@ -1800,4 +2015,18 @@ packages:
     name: yocto-queue
     version: 0.1.0
     engines: {node: '>=10'}
+    dev: false
+
+  registry.npmjs.org/zen-observable-ts/1.2.3:
+    resolution: {integrity: sha512-hc/TGiPkAWpByykMwDcem3SdUgA4We+0Qb36bItSuJC9xD0XVBZoFHYoadAomDSNf64CG8Ydj0Qb8Od8BUWz5g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.3.tgz}
+    name: zen-observable-ts
+    version: 1.2.3
+    dependencies:
+      zen-observable: registry.npmjs.org/zen-observable/0.8.15
+    dev: false
+
+  registry.npmjs.org/zen-observable/0.8.15:
+    resolution: {integrity: sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz}
+    name: zen-observable
+    version: 0.8.15
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,9 +18,7 @@ importers:
       core-js: ^3.0.0
       graphql: 16.0.1
       husky: 7.0.4
-      js-cookie: 3.0.1
       jsonc-parser: 3.0.0
-      lodash: 4.17.21
       react: 17.0.2
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
@@ -32,9 +30,7 @@ importers:
       core-js: registry.npmjs.org/core-js/3.20.0
       graphql: registry.npmjs.org/graphql/16.0.1
       husky: registry.npmjs.org/husky/7.0.4
-      js-cookie: registry.npmjs.org/js-cookie/3.0.1
       jsonc-parser: registry.npmjs.org/jsonc-parser/3.0.0
-      lodash: registry.npmjs.org/lodash/4.17.21
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     devDependencies:
@@ -1144,13 +1140,6 @@ packages:
     version: 26.3.0
     engines: {node: '>= 10.14.2'}
     dev: true
-
-  registry.npmjs.org/js-cookie/3.0.1:
-    resolution: {integrity: sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz}
-    name: js-cookie
-    version: 3.0.1
-    engines: {node: '>=12'}
-    dev: false
 
   registry.npmjs.org/js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz}

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -46,9 +46,6 @@
       "peerDependencies": {
         "@apollo/client": "^3.5.5",
         "graphql": "16.0.1",
-        "js-cookie": "3.0.1",
-        "lodash": "4.17.21",
-        "react": "17.0.2",
         "react": "17.0.2",
         "react-dom": "17.0.2"
       }

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -44,6 +44,11 @@
         "jsonc-parser": "3.0.0"
       },
       "peerDependencies": {
+        "@apollo/client": "^3.5.5",
+        "graphql": "16.0.1",
+        "js-cookie": "3.0.1",
+        "lodash": "4.17.21",
+        "react": "17.0.2",
         "react": "17.0.2",
         "react-dom": "17.0.2"
       }
@@ -57,6 +62,10 @@
    * see https://harmony-docs.bit.dev/aspects/variants for more info.
    **/
   "teambit.workspace/variants": {
+    "api": {
+      "defaultScope": "dtothefp.api",
+      "teambit.react/react": {}
+    },
     "scripts": {
       "defaultScope": "dtothefp.scripts",
       "teambit.harmony/node": {}

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -39,6 +39,7 @@
     "packageManager": "teambit.dependencies/pnpm",
     "policy": {
       "dependencies": {
+        "@teambit/dependencies.modules.packages-excluder": "0.0.49",
         "@testing-library/react": "12.1.2",
         "chalk": "4.1.2",
         "jsonc-parser": "3.0.0"
@@ -59,9 +60,12 @@
    * see https://harmony-docs.bit.dev/aspects/variants for more info.
    **/
   "teambit.workspace/variants": {
+    "envs": {
+      "defaultScope": "dtothefp.envs"
+    },
     "api": {
       "defaultScope": "dtothefp.api",
-      "teambit.react/react": {}
+      "dtothefp.envs/custom-react-env": {}
     },
     "scripts": {
       "defaultScope": "dtothefp.scripts",


### PR DESCRIPTION
#### To Test
- `bit install`
- `bit test`

```
▶ bit test
testing total of 1 components in workspace 'bit-exporter'
testing 1 components with environment teambit.react/react

 FAIL  api/initialize-apollo/initialize-apollo.spec.ts
  ● Test suite failed to run

    TypeError: _client.HttpLink is not a constructor

      10 | const apiKey = process.env.NEXT_PUBLIC_APPSYNC_API_KEY || '';
      11 |
    > 12 | const httpLink = new HttpLink({
         |                  ^
      13 |   uri,
      14 |   headers: {
      15 |     'x-api-key': apiKey,

      at Object.<anonymous> (api/initialize-apollo/initialize-apollo.ts:12:18)
      at Object.<anonymous> (api/initialize-apollo/initialize-apollo.spec.ts:1:1)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        1.717 s
Ran all test suites.
tested 1 components in 3.41 seconds.
```